### PR TITLE
Fixing handling of brackets in for/enhanced for/pattern enhanced for disambiguation.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3033,8 +3033,10 @@ public class JavacParser implements Parser {
                     break;
                 case LBRACKET:
                     if (peekToken(lookahead, RBRACKET)) {
-                        return ForInitResult.LocalVarDecl;
+                        return inSelectionAndParenthesis ? ForInitResult.RecordPattern
+                                                         : ForInitResult.LocalVarDecl;
                     }
+                    return ForInitResult.LocalVarDecl;
                 case LT:
                     depth++; break;
                 case GTGTGT:

--- a/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
+++ b/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
@@ -36,16 +36,30 @@ import com.sun.source.tree.CaseLabelTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ConstantCaseLabelTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.PatternCaseLabelTree;
+import com.sun.source.tree.PatternTree;
+import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.main.Option;
+import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Options;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
 
 public class DisambiguatePatterns {
 
@@ -111,14 +125,27 @@ public class DisambiguatePatterns {
                                  ExpressionType.EXPRESSION);
         test.disambiguationTest("a & b",
                                  ExpressionType.EXPRESSION);
+        test.forDisambiguationTest("T[] a", ForType.ENHANCED_FOR);
+        test.forDisambiguationTest("T[].class.getName()", ForType.TRADITIONAL_FOR);
+        test.forDisambiguationTest("T[].class", ForType.TRADITIONAL_FOR, "compiler.err.not.stmt");
+        test.forDisambiguationTest("R(T[] a)", ForType.ENHANCED_FOR_WITH_PATTERNS);
     }
 
     private final ParserFactory factory;
+    private final List<String> errors = new ArrayList<>();
 
-    public DisambiguatePatterns() {
+    public DisambiguatePatterns() throws URISyntaxException {
         Context context = new Context();
+        context.put(DiagnosticListener.class, d -> {
+            if (d.getKind() == Diagnostic.Kind.ERROR) {
+                errors.add(d.getCode());
+            }
+        });
         JavacFileManager jfm = new JavacFileManager(context, true, Charset.defaultCharset());
         Options.instance(context).put(Option.PREVIEW, "");
+        SimpleJavaFileObject source =
+                new SimpleJavaFileObject(new URI("mem://Test.java"), JavaFileObject.Kind.SOURCE) {};
+        Log.instance(context).useSource(source);
         factory = ParserFactory.instance(context);
     }
 
@@ -149,9 +176,66 @@ public class DisambiguatePatterns {
         }
     }
 
+    void forDisambiguationTest(String snippet, ForType forType, String... expectedErrors) {
+        errors.clear();
+
+        String codeTemplate = switch (forType) {
+            case TRADITIONAL_FOR ->
+                """
+                public class Test {
+                    private void test() {
+                        for (SNIPPET; ;) {
+                        }
+                    }
+                }
+                """;
+            case ENHANCED_FOR, ENHANCED_FOR_WITH_PATTERNS ->
+                """
+                public class Test {
+                    private void test() {
+                        for (SNIPPET : collection) {
+                        }
+                    }
+                }
+                """;
+        };
+
+        String code = codeTemplate.replace("SNIPPET", snippet);
+        JavacParser parser = factory.newParser(code, false, false, false);
+        CompilationUnitTree result = parser.parseCompilationUnit();
+        if (!Arrays.asList(expectedErrors).equals(errors)) {
+            throw new AssertionError("Expected errors: " + Arrays.asList(expectedErrors) +
+                                     ", actual: " + errors +
+                                     ", for: " + code);
+        }
+        ClassTree clazz = (ClassTree) result.getTypeDecls().get(0);
+        MethodTree method = (MethodTree) clazz.getMembers().get(0);
+        StatementTree st = method.getBody().getStatements().get(0);
+        if (forType == ForType.TRADITIONAL_FOR) {
+            if (st.getKind() != Kind.FOR_LOOP) {
+                throw new AssertionError("Unpected statement: " + st);
+            }
+        } else {
+            EnhancedForLoopTree ef = (EnhancedForLoopTree) st;
+            ForType actualType = switch (ef.getVariableOrRecordPattern()) {
+                case PatternTree pattern -> ForType.ENHANCED_FOR_WITH_PATTERNS;
+                default -> ForType.ENHANCED_FOR;
+            };
+            if (forType != actualType) {
+                throw new AssertionError("Expected: " + forType + ", actual: " + actualType +
+                                          ", for: " + code + ", parsed: " + result);
+            }
+        }
+    }
+
     enum ExpressionType {
         PATTERN,
         EXPRESSION;
     }
 
+    enum ForType {
+        TRADITIONAL_FOR,
+        ENHANCED_FOR,
+        ENHANCED_FOR_WITH_PATTERNS;
+    }
 }


### PR DESCRIPTION
As part of code analysis runs, it turned out there's a fall-through from `case LBRACKET` to `case LT` in `analyzeForInit`. While that does not seem to have any bad effect, the handling of `[]` does not seem to be quite right (`[]` can be part of either a pattern or a variable declaration, depending on the context), and this patch is trying to fix that. While also preventing the fall-through, as that does not seem to be necessary. Eventually, we may want to clean the method more thoroughly.
